### PR TITLE
Use numpy arrays for speed

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,6 +1,6 @@
 import os
-import random
 import torch
+import numpy as np
 from torch import optim
 
 from model import DQN
@@ -43,7 +43,7 @@ class Agent():
 
   # Acts with an ε-greedy policy (used for evaluation only)
   def act_e_greedy(self, state, epsilon=0.001):  # High ε can reduce evaluation scores drastically
-    return random.randrange(self.action_space) if random.random() < epsilon else self.act(state)
+    return np.random.randrange(self.action_space) if np.random.random() < epsilon else self.act(state)
 
   def learn(self, mem):
     # Sample transitions

--- a/agent.py
+++ b/agent.py
@@ -1,6 +1,6 @@
 import os
-import torch
 import numpy as np
+import torch
 from torch import optim
 
 from model import DQN

--- a/agent.py
+++ b/agent.py
@@ -43,7 +43,7 @@ class Agent():
 
   # Acts with an ε-greedy policy (used for evaluation only)
   def act_e_greedy(self, state, epsilon=0.001):  # High ε can reduce evaluation scores drastically
-    return np.random.randrange(self.action_space) if np.random.random() < epsilon else self.act(state)
+    return np.random.randint(0, self.action_space) if np.random.random() < epsilon else self.act(state)
 
   def learn(self, mem):
     # Sample transitions

--- a/env.py
+++ b/env.py
@@ -1,8 +1,8 @@
 from collections import deque
 import random
 import atari_py
+import cv2
 import torch
-import cv2  # Note that importing cv2 before torch may cause segfaults?
 
 
 class Env():

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - plotly
   - pytorch
+  - tqdm
   - pip:
     - atari-py
     - opencv-python

--- a/main.py
+++ b/main.py
@@ -1,12 +1,13 @@
 import argparse
 from datetime import datetime
-import random
+import numpy as np
 import torch
 
 from agent import Agent
 from env import Env
 from memory import ReplayMemory
 from test import test
+from tqdm import tqdm
 
 
 parser = argparse.ArgumentParser(description='Rainbow')
@@ -47,12 +48,12 @@ args = parser.parse_args()
 print(' ' * 26 + 'Options')
 for k, v in vars(args).items():
   print(' ' * 26 + k + ': ' + str(v))
-random.seed(args.seed)
-torch.manual_seed(random.randint(1, 10000))
+np.random.seed(args.seed)
+torch.manual_seed(np.random.randint(1, 10000))
 if torch.cuda.is_available() and not args.disable_cuda:
   args.device = torch.device('cuda')
-  torch.cuda.manual_seed(random.randint(1, 10000))
-  torch.backends.cudnn.enabled = False  # Disable nondeterministic ops (not sure if critical but better safe than sorry)
+  torch.cuda.manual_seed(np.random.randint(1, 10000))
+  # torch.backends.cudnn.enabled = False  # Disable nondeterministic ops (not sure if critical but better safe than sorry)
 else:
   args.device = torch.device('cpu')
 
@@ -81,7 +82,7 @@ while T < args.evaluation_size:
   if done:
     state, done = env.reset(), False
 
-  next_state, _, done = env.step(random.randint(0, action_space - 1))
+  next_state, _, done = env.step(np.random.randint(0, action_space - 1))
   val_mem.append(state, None, None, done)
   state = next_state
   T += 1
@@ -94,10 +95,10 @@ else:
   # Training loop
   dqn.train()
   T, done = 0, True
-  while T < args.T_max:
+  for T in tqdm(range(args.T_max)):
     if done:
       state, done = env.reset(), False
-    
+
     if T % args.replay_frequency == 0:
       dqn.reset_noise()  # Draw a new set of noisy weights
 

--- a/main.py
+++ b/main.py
@@ -39,7 +39,6 @@ parser.add_argument('--evaluate', action='store_true', help='Evaluate only')
 parser.add_argument('--evaluation-interval', type=int, default=100000, metavar='STEPS', help='Number of training steps between evaluations')
 parser.add_argument('--evaluation-episodes', type=int, default=10, metavar='N', help='Number of evaluation episodes to average over')
 parser.add_argument('--evaluation-size', type=int, default=500, metavar='N', help='Number of transitions to use for validating Q')
-parser.add_argument('--log-interval', type=int, default=25000, metavar='STEPS', help='Number of training steps between logging status')
 parser.add_argument('--render', action='store_true', help='Display screen (testing only)')
 
 
@@ -53,7 +52,7 @@ torch.manual_seed(np.random.randint(1, 10000))
 if torch.cuda.is_available() and not args.disable_cuda:
   args.device = torch.device('cuda')
   torch.cuda.manual_seed(np.random.randint(1, 10000))
-  # torch.backends.cudnn.enabled = False  # Disable nondeterministic ops (not sure if critical but better safe than sorry)
+  torch.backends.cudnn.enabled = False  # Disable nondeterministic ops (not sure if critical but better safe than sorry)
 else:
   args.device = torch.device('cpu')
 
@@ -82,7 +81,7 @@ while T < args.evaluation_size:
   if done:
     state, done = env.reset(), False
 
-  next_state, _, done = env.step(np.random.randint(0, action_space - 1))
+  next_state, _, done = env.step(np.random.randint(0, action_space))
   val_mem.append(state, None, None, done)
   state = next_state
   T += 1
@@ -108,9 +107,6 @@ else:
       reward = max(min(reward, args.reward_clip), -args.reward_clip)  # Clip rewards
     mem.append(state, action, reward, done)  # Append transition to memory
     T += 1
-
-    if T % args.log_interval == 0:
-      log('T = ' + str(T) + ' / ' + str(args.T_max))
 
     # Train and test
     if T >= args.learn_start:

--- a/memory.py
+++ b/memory.py
@@ -15,7 +15,7 @@ class SegmentTree():
     self.full = False  # Used to track actual capacity
     self.sum_tree = np.zeros((2 * size - 1, ), dtype=np.float32)  # Initialise fixed size tree with all (priority) zeros
     self.data = np.array([None] * size)  # Wrap-around cyclic buffer
-    self.max = np.array([1], dtype=np.int32)  # Initial max value to return (1 = 1^ω)
+    self.max = 1  # Initial max value to return (1 = 1^ω)
 
   # Propagates value up tree given a tree index
   def _propagate(self, index, value):
@@ -27,16 +27,16 @@ class SegmentTree():
 
   # Updates value given a tree index
   def update(self, index, value):
-    self.sum_tree[index] = np.array(value, dtype=np.int32)  # Set new value
+    self.sum_tree[index] = value  # Set new value
     self._propagate(index, value)  # Propagate value
-    self.max = np.maximum(value, self.max)
+    self.max = max(value, self.max)
 
   def append(self, data, value):
     self.data[self.index] = data  # Store data in underlying data structure
     self.update(self.index + self.size - 1, value)  # Update tree
     self.index = (self.index + 1) % self.size  # Update index
     self.full = self.full or self.index == 0  # Save when capacity reached
-    self.max = np.maximum(value, self.max)
+    self.max = max(value, self.max)
 
   # Searches for the location of a value in sum tree
   def _retrieve(self, index, value):

--- a/memory.py
+++ b/memory.py
@@ -1,4 +1,3 @@
-import random
 from collections import namedtuple
 import torch
 import numpy as np
@@ -14,9 +13,9 @@ class SegmentTree():
     self.index = 0
     self.size = size
     self.full = False  # Used to track actual capacity
-    self.sum_tree = [0] * (2 * size - 1)  # Initialise fixed size tree with all (priority) zeros
-    self.data = [None] * size  # Wrap-around cyclic buffer
-    self.max = 1  # Initial max value to return (1 = 1^ω)
+    self.sum_tree = np.array([0] * (2 * size - 1), dtype=np.int32)  # Initialise fixed size tree with all (priority) zeros
+    self.data = np.array([None] * size)  # Wrap-around cyclic buffer
+    self.max = np.array([1], dtype=np.int32)  # Initial max value to return (1 = 1^ω)
 
   # Propagates value up tree given a tree index
   def _propagate(self, index, value):
@@ -28,16 +27,16 @@ class SegmentTree():
 
   # Updates value given a tree index
   def update(self, index, value):
-    self.sum_tree[index] = value  # Set new value
+    self.sum_tree[index] = np.array(value, dtype=np.int32)  # Set new value
     self._propagate(index, value)  # Propagate value
-    self.max = max(value, self.max)
+    self.max = np.maximum(value, self.max)
 
   def append(self, data, value):
     self.data[self.index] = data  # Store data in underlying data structure
     self.update(self.index + self.size - 1, value)  # Update tree
     self.index = (self.index + 1) % self.size  # Update index
     self.full = self.full or self.index == 0  # Save when capacity reached
-    self.max = max(value, self.max)
+    self.max = np.maximum(value, self.max)
 
   # Searches for the location of a value in sum tree
   def _retrieve(self, index, value):
@@ -82,7 +81,7 @@ class ReplayMemory():
 
   # Returns a transition with blank states where appropriate
   def _get_transition(self, idx):
-    transition = [None] * (self.history + self.n)
+    transition = np.array([None] * (self.history + self.n))
     transition[self.history - 1] = self.transitions.get(idx)
     for t in range(self.history - 2, -1, -1):  # e.g. 2 1 0
       if transition[t + 1].timestep == 0:
@@ -100,7 +99,7 @@ class ReplayMemory():
   def _get_sample_from_segment(self, segment, i):
     valid = False
     while not valid:
-      sample = random.uniform(i * segment, (i + 1) * segment)  # Uniformly sample an element from within a segment
+      sample = np.random.uniform(i * segment, (i + 1) * segment)  # Uniformly sample an element from within a segment
       prob, idx, tree_idx = self.transitions.find(sample)  # Retrieve sample from tree with un-normalised probability
       # Resample if transition straddled current index or probablity 0
       if (self.transitions.index - idx) % self.capacity > self.n and (idx - self.transitions.index) % self.capacity >= self.history and prob != 0:

--- a/memory.py
+++ b/memory.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
-import torch
 import numpy as np
+import torch
 
 
 Transition = namedtuple('Transition', ('timestep', 'state', 'action', 'reward', 'nonterminal'))
@@ -13,7 +13,7 @@ class SegmentTree():
     self.index = 0
     self.size = size
     self.full = False  # Used to track actual capacity
-    self.sum_tree = np.array([0] * (2 * size - 1), dtype=np.int32)  # Initialise fixed size tree with all (priority) zeros
+    self.sum_tree = np.zeros((2 * size - 1, ), dtype=np.float32)  # Initialise fixed size tree with all (priority) zeros
     self.data = np.array([None] * size)  # Wrap-around cyclic buffer
     self.max = np.array([1], dtype=np.int32)  # Initial max value to return (1 = 1^ω)
 

--- a/memory.py
+++ b/memory.py
@@ -126,10 +126,10 @@ class ReplayMemory():
     probs, idxs, tree_idxs, states, actions, returns, next_states, nonterminals = zip(*batch)
     states, next_states, = torch.stack(states), torch.stack(next_states)
     actions, returns, nonterminals = torch.cat(actions), torch.cat(returns), torch.stack(nonterminals)
-    probs = np.array(probs, dtype = np.float32)/p_total # Calculate normalised probabilities
+    probs = np.array(probs, dtype=np.float32) / p_total  # Calculate normalised probabilities
     capacity = self.capacity if self.transitions.full else self.transitions.index
     weights = (capacity * probs) ** -self.priority_weight  # Compute importance-sampling weights w
-    weights = torch.tensor(weights / weights.max(), dtype=torch.float32, device=self.device)   # Normalise by max importance-sampling weight from batch
+    weights = torch.tensor(weights / weights.max(), dtype=torch.float32, device=self.device)  # Normalise by max importance-sampling weight from batch
     return tree_idxs, states, actions, returns, next_states, nonterminals, weights
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ atari-py
 opencv-python
 plotly
 pytorch
+tqdm


### PR DESCRIPTION
@ahundt I noticed that you made some adjustments that apparently improve the speed of this code. Would you be willing to contribute these back? I had some questions for `memory.py`:

- `sum_tree` holds priorities, so the data type should be `np.float32`, not `np.int32`?
- Is much saved by making `max` a 1D numpy array?
- Is it worth it to explicitly cast priorities (`value`) into a 1D numpy array before inserting them into `sum_tree`?