### PR TITLE
Fix requirements.txt: replace "pytorch" with "torch"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 atari-py
 opencv-python
 plotly
-pytorch
+torch
 tqdm


### PR DESCRIPTION
With this change, pip users can `pip install -r requirements.txt`