### PR TITLE
Fix stddev default to match NoisyNet paper

### DIFF
--- a/model.py
+++ b/model.py
@@ -6,7 +6,7 @@ from torch.nn import functional as F
 
 # Factorised NoisyLinear layer with bias
 class NoisyLinear(nn.Module):
-  def __init__(self, in_features, out_features, std_init=0.4):
+  def __init__(self, in_features, out_features, std_init=0.5):
     super(NoisyLinear, self).__init__()
     self.in_features = in_features
     self.out_features = out_features


### PR DESCRIPTION
Small change to correct the default standard deviation initialization parameter for Factorized Noisy Nets.

For an out-of-the-box replication, this matches the published research.

### References

[(Fortunato et al. 2017) _Noisy Networks for Exploration_](https://arxiv.org/pdf/1706.10295.pdf) - Section 3.2, last sentence.

[(Hessel et al. 2017) _Rainbow: Combining Improvements in Deep Reinforcement Learning_](https://arxiv.org/pdf/1710.02298.pdf) - Table 1

