### PR TITLE
Resume support

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -100,8 +100,8 @@ class Agent():
     self.target_net.load_state_dict(self.online_net.state_dict())
 
   # Save model parameters on current device (don't move model between devices)
-  def save(self, path):
-    torch.save(self.online_net.state_dict(), os.path.join(path, 'model.pth'))
+  def save(self, path, name='model.pth'):
+    torch.save(self.online_net.state_dict(), os.path.join(path, name))
 
   # Evaluates Q-value based on single state (no batch)
   def evaluate_q(self, state):

--- a/main.py
+++ b/main.py
@@ -84,7 +84,6 @@ def load_memory(memory_path, disable_bzip):
   if disable_bzip:
     with open(memory_path, 'rb') as pickle_file:
       return pickle.load(pickle_file)
-
   else:
     with bz2.open(memory_path, 'rb') as zipped_pickle_file:
       return pickle.load(zipped_pickle_file)
@@ -94,7 +93,6 @@ def save_memory(memory, memory_path, disable_bzip):
   if disable_bzip:
     with open(memory_path, 'wb') as pickle_file:
       pickle.dump(memory, pickle_file)
-
   else:
     with bz2.open(memory_path, 'wb') as zipped_pickle_file:
       pickle.dump(memory, zipped_pickle_file)
@@ -112,8 +110,7 @@ dqn = Agent(args, env)
 if args.model is not None and not args.evaluate:
   if not args.memory:
     raise ValueError('Cannot resume training without memory save path. Aborting...')
-
-  if not os.path.exists(args.memory):
+  elif not os.path.exists(args.memory):
     raise ValueError('Could not find memory file at {path}. Aborting...'.format(path=args.memory))
 
   mem = load_memory(args.memory, args.disable_bzip_memory)

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from agent import Agent
 from env import Env
 from memory import ReplayMemory
 from test import test
-from tqdm import tqdm
+from tqdm import trange
 import pickle
 import bz2
 
@@ -145,7 +145,7 @@ else:
   # Training loop
   dqn.train()
   T, done = 0, True
-  for T in tqdm(range(args.T_max)):
+  for T in trange(1, args.T_max + 1):
     if done:
       state, done = env.reset(), False
 

--- a/main.py
+++ b/main.py
@@ -51,11 +51,16 @@ parser.add_argument('--evaluation-size', type=int, default=500, metavar='N', hel
 parser.add_argument('--render', action='store_true', help='Display screen (testing only)')
 parser.add_argument('--enable-cudnn', action='store_true', help='Enable cuDNN (faster but nondeterministic)')
 
+parser.add_argument('--checkpoint-interval', default=None, help='How often to checkpoint the model, defaults to the evaluation interval')
 parser.add_argument('--memory-save-path', help='Path to save/load the memory from')
 parser.add_argument('--dont-bzip-memory', action='store_true', help='Don\'t zip the memory file. Not recommended (zipping is a bit slower and much, much smaller)')
 
 # Setup
 args = parser.parse_args()
+
+if args.checkpoint_interval is None:
+  args.checkpoint_interval = args.evaluation_interval
+
 print(' ' * 26 + 'Options')
 for k, v in vars(args).items():
   print(' ' * 26 + k + ': ' + str(v))
@@ -178,6 +183,10 @@ else:
       # Update target network
       if T % args.target_update == 0:
         dqn.update_target_net()
+
+      # Checkpoint the network
+      if T % args.checkpoint_interval == 0:
+        dqn.save(results_dir, 'checkpoint.pth')
 
     state = next_state
 


### PR DESCRIPTION
Added preliminary support for resuming. Initial testing looks like it works, but I'd appreciate if anyone else gets a chance to play with it in their setup. 

I didn't add an explicit resume flag, although we could do that. Currently, the assumption is that if you provide the `--memory-save-path` argument, you want the memory saved there, by default after every testing round. If you provide the `--model` argument and do not provide the `--evaluate `flag, the assumption is that you want to resume, and that `--memory-save-path` exists.

Another flag we could add is a `--T_start` flag, akin to `--T_max`, in order to specify where training is resuming from to better the logging of resumed models. What do you think?

Choosing to compress at all, and choosing to use bz2 specifically, came after a quick benchmark  I did with some pickled memories I had. It drops them from ~2GB to <100 MB, and bz2 took somewhere around 2-3 minutes, while pickling without it took around 40 seconds.