### PR TITLE
Efficient vectorized ReplayMemory and SegmentTree

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,7 +131,7 @@ while T < args.evaluation_size:
     state, done = env.reset(), False
 
   next_state, _, done = env.step(np.random.randint(0, action_space))
-  val_mem.append(state, None, None, done)
+  val_mem.append(state, -1, 0.0, done)
   state = next_state
   T += 1
 

--- a/memory.py
+++ b/memory.py
@@ -33,12 +33,12 @@ class SegmentTree():
       self._propagate(parents)
 
   # Propagates single value up tree given a tree index for efficiency
-  def _propagate_index(self, index, value):
+  def _propagate_index(self, index):
     parent = (index - 1) // 2
     left, right = 2 * parent + 1, 2 * parent + 2
     self.sum_tree[parent] = self.sum_tree[left] + self.sum_tree[right]
     if parent != 0:
-      self._propagate_index(parent, value)
+      self._propagate_index(parent)
 
   # Updates values given tree indices
   def update(self, indices, values):
@@ -50,7 +50,7 @@ class SegmentTree():
   # Updates single value given a tree index for efficiency
   def _update_index(self, index, value):
     self.sum_tree[index] = value  # Set new value
-    self._propagate_index(index, value)  # Propagate value
+    self._propagate_index(index)  # Propagate value
     self.max = max(value, self.max)
 
   def append(self, data, value):

--- a/memory.py
+++ b/memory.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import division
-from collections import namedtuple
 import numpy as np
 import torch
 
 
-Transition = namedtuple('Transition', ('timestep', 'state', 'action', 'reward', 'nonterminal'))
-blank_trans = Transition(0, torch.zeros(84, 84, dtype=torch.uint8), None, 0, False)
+Transition_dtype = np.dtype([('timestep', np.int32), ('state', np.uint8, (84, 84)), ('action', np.int32), ('reward', np.float32), ('nonterminal', np.bool_)])
+blank_trans = (0, np.zeros((84, 84), dtype=np.uint8), 0, 0.0, False)
 
 
 # Segment tree data structure where parent node values are sum/max of children node values
@@ -15,46 +14,71 @@ class SegmentTree():
     self.index = 0
     self.size = size
     self.full = False  # Used to track actual capacity
-    self.sum_tree = np.zeros((2 * size - 1, ), dtype=np.float32)  # Initialise fixed size tree with all (priority) zeros
-    self.data = np.array([None] * size)  # Wrap-around cyclic buffer
+    self.tree_start = 1
+    while self.tree_start < self.size: # Put all used node leaves on last tree level
+      self.tree_start *= 2
+    self.tree_start -= 1
+    self.sum_tree = np.zeros((self.tree_start + self.size,), dtype=np.float32)
+    self.data = np.array([blank_trans] * size, dtype=Transition_dtype)  # Build structured array
     self.max = 1  # Initial max value to return (1 = 1^ω)
 
-  # Propagates value up tree given a tree index
-  def _propagate(self, index, value):
+  # Updates nodes values from current tree
+  def _update_nodes(self, indices):
+    children_indices = indices * 2 + np.expand_dims([1, 2], axis=1)
+    self.sum_tree[indices] = np.sum(self.sum_tree[children_indices], axis=0)
+
+  # Propagates changes up tree given tree indices
+  def _propagate(self, indices):
+    parents = (indices - 1) // 2
+    unique_parents = np.unique(parents)
+    self._update_nodes(unique_parents)
+    if parents[0] != 0:
+      self._propagate(parents)
+
+  # Propagates single value up tree given a tree index for efficiency
+  def _propagate_index(self, index, value):
     parent = (index - 1) // 2
     left, right = 2 * parent + 1, 2 * parent + 2
     self.sum_tree[parent] = self.sum_tree[left] + self.sum_tree[right]
     if parent != 0:
-      self._propagate(parent, value)
+      self._propagate_index(parent, value)
 
-  # Updates value given a tree index
-  def update(self, index, value):
+  # Updates values given tree indices
+  def update(self, indices, values):
+    self.sum_tree[indices] = values  # Set new values
+    self._propagate(indices)  # Propagate values
+    current_max_value = np.max(values)
+    self.max = max(current_max_value, self.max)
+
+  # Updates single value given a tree index for efficiency
+  def _update_index(self, index, value):
     self.sum_tree[index] = value  # Set new value
-    self._propagate(index, value)  # Propagate value
+    self._propagate_index(index, value)  # Propagate value
     self.max = max(value, self.max)
 
   def append(self, data, value):
     self.data[self.index] = data  # Store data in underlying data structure
-    self.update(self.index + self.size - 1, value)  # Update tree
+    self._update_index(self.index + self.tree_start, value)  # Update tree
     self.index = (self.index + 1) % self.size  # Update index
     self.full = self.full or self.index == 0  # Save when capacity reached
     self.max = max(value, self.max)
 
-  # Searches for the location of a value in sum tree
-  def _retrieve(self, index, value):
-    left, right = 2 * index + 1, 2 * index + 2
-    if left >= len(self.sum_tree):
-      return index
-    elif value <= self.sum_tree[left]:
-      return self._retrieve(left, value)
-    else:
-      return self._retrieve(right, value - self.sum_tree[left])
+  # Searches for the location of values in sum tree
+  def _retrieve(self, indices, values):
+    children_indices = (indices * 2 + np.expand_dims([1, 2], axis=1)) # Make matrix of children indices
+    if children_indices[0, 0] >= self.sum_tree.shape[0]:
+      return indices
+    left_children_values = self.sum_tree[children_indices[0]]
+    successor_choices = np.greater(values, left_children_values).astype(np.int32)  # Classify which values are in left or right branches
+    successor_indices = children_indices[successor_choices, np.arange(indices.size)] # Use classification to index into the indices matrix
+    successor_values = values - successor_choices * left_children_values  # Subtract the left branch values when searching in the right branch
+    return self._retrieve(successor_indices, successor_values)
 
-  # Searches for a value in sum tree and returns value, data index and tree index
-  def find(self, value):
-    index = self._retrieve(0, value)  # Search for index of item from root
-    data_index = index - self.size + 1
-    return (self.sum_tree[index], data_index, index)  # Return value, data index, tree index
+  # Searches for values in sum tree and returns values, data indices and tree indices
+  def find(self, values):
+    indices = self._retrieve(np.zeros(values.shape, dtype=np.int32), values)
+    data_index = indices - self.tree_start
+    return (self.sum_tree[indices], data_index, indices)  # Return values, data indices, tree indices
 
   # Returns data given a data index
   def get(self, data_index):
@@ -73,71 +97,65 @@ class ReplayMemory():
     self.priority_weight = args.priority_weight  # Initial importance sampling weight β, annealed to 1 over course of training
     self.priority_exponent = args.priority_exponent
     self.t = 0  # Internal episode timestep counter
+    self.reward_scaling = torch.tensor([self.discount ** i for i in range(self.n)], dtype=torch.float32, device=self.device)  # Discount-scaling vector for n future rewards
     self.transitions = SegmentTree(capacity)  # Store transitions in a wrap-around cyclic buffer within a sum tree for querying priorities
 
   # Adds state and action at time t, reward and terminal at time t + 1
   def append(self, state, action, reward, terminal):
     state = state[-1].mul(255).to(dtype=torch.uint8, device=torch.device('cpu'))  # Only store last frame and discretise to save memory
-    self.transitions.append(Transition(self.t, state, action, reward, not terminal), self.transitions.max)  # Store new transition with maximum priority
+    self.transitions.append((self.t, state, action, reward, not terminal), self.transitions.max)  # Store new transition with maximum priority
     self.t = 0 if terminal else self.t + 1  # Start new episodes with t = 0
 
-  # Returns a transition with blank states where appropriate
-  def _get_transition(self, idx):
-    transition = np.array([None] * (self.history + self.n))
-    transition[self.history - 1] = self.transitions.get(idx)
+  # Returns the transitions with blank states where appropriate
+  def _get_transitions(self, idxs):
+    transition_idxs = np.arange(-self.history + 1, self.n + 1) + np.expand_dims(idxs, axis=1)
+    transitions = self.transitions.get(transition_idxs)
+    transitions_firsts = transitions['timestep'] == 0
+    blank_mask = np.zeros_like(transitions_firsts, dtype=np.bool_)
     for t in range(self.history - 2, -1, -1):  # e.g. 2 1 0
-      if transition[t + 1].timestep == 0:
-        transition[t] = blank_trans  # If future frame has timestep 0
-      else:
-        transition[t] = self.transitions.get(idx - self.history + 1 + t)
+      blank_mask[:, t] = np.logical_or(blank_mask[:, t + 1], transitions_firsts[:, t + 1]) # True if future frame has timestep 0
     for t in range(self.history, self.history + self.n):  # e.g. 4 5 6
-      if transition[t - 1].nonterminal:
-        transition[t] = self.transitions.get(idx - self.history + 1 + t)
-      else:
-        transition[t] = blank_trans  # If prev (next) frame is terminal
-    return transition
+      blank_mask[:, t] = np.logical_or(blank_mask[:, t - 1], transitions_firsts[:, t]) # True if current or past frame has timestep 0
+    transitions[blank_mask] = blank_trans
+    return transitions
 
-  # Returns a valid sample from a segment
-  def _get_sample_from_segment(self, segment, i):
+  # Returns a valid sample from each segment
+  def _get_samples_from_segments(self, batch_size, p_total):
+    segment_length = p_total / batch_size  # Batch size number of segments, based on sum over all probabilities
+    segment_starts = np.arange(batch_size) * segment_length
     valid = False
     while not valid:
-      sample = np.random.uniform(i * segment, (i + 1) * segment)  # Uniformly sample an element from within a segment
-      prob, idx, tree_idx = self.transitions.find(sample)  # Retrieve sample from tree with un-normalised probability
-      # Resample if transition straddled current index or probablity 0
-      if (self.transitions.index - idx) % self.capacity > self.n and (idx - self.transitions.index) % self.capacity >= self.history and prob != 0:
+      samples = np.random.uniform(0.0, segment_length, [batch_size]) + segment_starts  # Uniformly sample from within all segments
+      probs, idxs, tree_idxs = self.transitions.find(samples)  # Retrieve samples from tree with un-normalised probability
+      if np.all((self.transitions.index - idxs) % self.capacity > self.n) and np.all((idxs - self.transitions.index) % self.capacity >= self.history) and np.all(probs != 0):
         valid = True  # Note that conditions are valid but extra conservative around buffer index 0
-
     # Retrieve all required transition data (from t - h to t + n)
-    transition = self._get_transition(idx)
-    # Create un-discretised state and nth next state
-    state = torch.stack([trans.state for trans in transition[:self.history]]).to(device=self.device).to(dtype=torch.float32).div_(255)
-    next_state = torch.stack([trans.state for trans in transition[self.n:self.n + self.history]]).to(device=self.device).to(dtype=torch.float32).div_(255)
-    # Discrete action to be used as index
-    action = torch.tensor([transition[self.history - 1].action], dtype=torch.int64, device=self.device)
-    # Calculate truncated n-step discounted return R^n = Σ_k=0->n-1 (γ^k)R_t+k+1 (note that invalid nth next states have reward 0)
-    R = torch.tensor([sum(self.discount ** n * transition[self.history + n - 1].reward for n in range(self.n))], dtype=torch.float32, device=self.device)
+    transitions = self._get_transitions(idxs)
+    # Create un-discretised states and nth next states
+    all_states = transitions['state']
+    states = torch.tensor(all_states[:, :self.history], device=self.device, dtype=torch.float32).div_(255)
+    next_states = torch.tensor(all_states[:, self.n:self.n + self.history], device=self.device, dtype=torch.float32).div_(255)
+    # Discrete actions to be used as index
+    actions = torch.tensor(np.copy(transitions['action'][:, self.history - 1]), dtype=torch.int64, device=self.device)
+    # Calculate truncated n-step discounted returns R^n = Σ_k=0->n-1 (γ^k)R_t+k+1 (note that invalid nth next states have reward 0)
+    rewards = torch.tensor(np.copy(transitions['reward'][:, self.history - 1:-1]), dtype=torch.float32, device=self.device)
+    R = torch.matmul(rewards, self.reward_scaling)
     # Mask for non-terminal nth next states
-    nonterminal = torch.tensor([transition[self.history + self.n - 1].nonterminal], dtype=torch.float32, device=self.device)
-
-    return prob, idx, tree_idx, state, action, R, next_state, nonterminal
+    nonterminals = torch.tensor(np.expand_dims(transitions['nonterminal'][:, self.history + self.n - 1], axis=1), dtype=torch.float32, device=self.device)
+    return probs, idxs, tree_idxs, states, actions, R, next_states, nonterminals
 
   def sample(self, batch_size):
     p_total = self.transitions.total()  # Retrieve sum of all priorities (used to create a normalised probability distribution)
-    segment = p_total / batch_size  # Batch size number of segments, based on sum over all probabilities
-    batch = [self._get_sample_from_segment(segment, i) for i in range(batch_size)]  # Get batch of valid samples
-    probs, idxs, tree_idxs, states, actions, returns, next_states, nonterminals = zip(*batch)
-    states, next_states, = torch.stack(states), torch.stack(next_states)
-    actions, returns, nonterminals = torch.cat(actions), torch.cat(returns), torch.stack(nonterminals)
-    probs = np.array(probs, dtype=np.float32) / p_total  # Calculate normalised probabilities
+    probs, idxs, tree_idxs, states, actions, returns, next_states, nonterminals = self._get_samples_from_segments(batch_size, p_total)  # Get batch of valid samples
+    probs = probs / p_total  # Calculate normalised probabilities
     capacity = self.capacity if self.transitions.full else self.transitions.index
     weights = (capacity * probs) ** -self.priority_weight  # Compute importance-sampling weights w
     weights = torch.tensor(weights / weights.max(), dtype=torch.float32, device=self.device)  # Normalise by max importance-sampling weight from batch
     return tree_idxs, states, actions, returns, next_states, nonterminals, weights
 
-
   def update_priorities(self, idxs, priorities):
     priorities = np.power(priorities, self.priority_exponent)
-    [self.transitions.update(idx, priority) for idx, priority in zip(idxs, priorities)]
+    self.transitions.update(idxs, priorities)
 
   # Set up internal state for iterator
   def __iter__(self):
@@ -148,17 +166,13 @@ class ReplayMemory():
   def __next__(self):
     if self.current_idx == self.capacity:
       raise StopIteration
-    # Create stack of states
-    state_stack = [None] * self.history
-    state_stack[-1] = self.transitions.data[self.current_idx].state
-    prev_timestep = self.transitions.data[self.current_idx].timestep
+    transitions = self.transitions.data[np.arange(self.current_idx - self.history + 1, self.current_idx + 1)]
+    transitions_firsts = transitions['timestep'] == 0
+    blank_mask = np.zeros_like(transitions_firsts, dtype=np.bool_)
     for t in reversed(range(self.history - 1)):
-      if prev_timestep == 0:
-        state_stack[t] = blank_trans.state  # If future frame has timestep 0
-      else:
-        state_stack[t] = self.transitions.data[self.current_idx + t - self.history + 1].state
-        prev_timestep -= 1
-    state = torch.stack(state_stack, 0).to(dtype=torch.float32, device=self.device).div_(255)  # Agent will turn into batch
+      blank_mask[t] = np.logical_or(blank_mask[t + 1], transitions_firsts[t + 1]) # If future frame has timestep 0
+    transitions[blank_mask] = blank_trans
+    state = torch.tensor(transitions['state'], dtype=torch.float32, device=self.device).div_(255)  # Agent will turn into batch
     self.current_idx += 1
     return state
 

--- a/memory.py
+++ b/memory.py
@@ -14,10 +14,7 @@ class SegmentTree():
     self.index = 0
     self.size = size
     self.full = False  # Used to track actual capacity
-    self.tree_start = 1
-    while self.tree_start < self.size: # Put all used node leaves on last tree level
-      self.tree_start *= 2
-    self.tree_start -= 1
+    self.tree_start = 2**(size-1).bit_length()-1  # Put all used node leaves on last tree level
     self.sum_tree = np.zeros((self.tree_start + self.size,), dtype=np.float32)
     self.data = np.array([blank_trans] * size, dtype=Transition_dtype)  # Build structured array
     self.max = 1  # Initial max value to return (1 = 1^ω)


### PR DESCRIPTION
I have noticed the prioritized buffer currently samples and updates elements in the segment tree one at a time. I have rewritten the segment tree and memory class to use efficient vectorized retrievals/updates. I used numpy's structured arrays to avoid having to index into multiple data matrices one at a time.

On my machine this leads to x2-x10 speedups when sampling/updating batches, cutting the overall training time from about 40 minutes (~45 it/s) to about 28 minutes (~65 it/s) when running data-efficient Rainbow.

I have made an additional branch called _parallel-memory-tests_ to briefly show (inside _memory_tests.ipynb_) that the new vectorized memory's behavior is identical to the current memory's behavior (when sampling deterministically) and the relative timings.