### PR TITLE
Replay buffer fix

### DIFF
--- a/model.py
+++ b/model.py
@@ -30,7 +30,7 @@ class NoisyLinear(nn.Module):
     self.bias_sigma.data.fill_(self.std_init / math.sqrt(self.out_features))
 
   def _scale_noise(self, size):
-    x = torch.randn(size)
+    x = torch.randn(size, device=self.weight_mu.device)
     return x.sign().mul_(x.abs().sqrt_())
 
   def reset_noise(self):


### PR DESCRIPTION
I got the following error on several different runs, making the library somewhat unusable:

```
  File ".../Rainbow/memory.py", line 68, in _retrieve
    left_children_values = self.sum_tree[children_indices[0]]
IndexError: index 2097149 is out of bounds for axis 0 with size 2048575
```

Seems to be a repeat of #76

Here is my proposed fix:

Does this seem like a valid fix?